### PR TITLE
Change vpa naming schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM keppel.eu-de-2.cloud.sap/ccloud-dockerhub-mirror/library/golang:1.17 as builder
+FROM keppel.eu-de-2.cloud.sap/ccloud-dockerhub-mirror/library/golang:1.19 as builder
 
 WORKDIR /workspace
 COPY . .
-RUN CGO_ENABLED=0 go build -o vpa_butler cmd/vpa_butler/main.go
+RUN make all
 
 FROM gcr.io/distroless/static:nonroot
 LABEL source_repository="https://github.com/sapcc/vpa_butler"
 WORKDIR /
-COPY --from=builder /workspace/vpa_butler .
+COPY --from=builder /workspace/bin/linux/vpa_butler .
 USER nonroot:nonroot
 ENTRYPOINT ["/vpa_butler"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: bin/$(GOOS)/$(BINARY)
 bin/%/$(BINARY): GIT_COMMIT  = $(shell git rev-parse --short HEAD)
 bin/%/$(BINARY): BUILD_DATE  = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 bin/%/$(BINARY): $(GOFILES) Makefile
-	GOOS=$* GOARCH=amd64 go build -ldflags '-X github.com/sapcc/vpa_butler/cmd.BuildCommit=$(GIT_COMMIT) -X github.com/sapcc/vpa_butler/cmd.BuildDate=$(BUILD_DATE)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/vpa_butler/main.go && chmod +x bin/$*/$(BINARY)
+	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags '-X main.Version=$(VERSION)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/vpa_butler/main.go && chmod +x bin/$*/$(BINARY)
 
 build:
 	docker build $(OPTS) -t $(IMAGE):$(VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,10 @@ all: bin/$(GOOS)/$(BINARY)
 bin/%/$(BINARY): GIT_COMMIT  = $(shell git rev-parse --short HEAD)
 bin/%/$(BINARY): BUILD_DATE  = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 bin/%/$(BINARY): $(GOFILES) Makefile
-	GOOS=$* GOARCH=amd64 go build -ldflags '-X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildCommit=$(GIT_COMMIT) -X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildDate=$(BUILD_DATE)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/main.go && chmod +x bin/$*/$(BINARY)
+	GOOS=$* GOARCH=amd64 go build -ldflags '-X github.com/sapcc/vpa_butler/cmd.BuildCommit=$(GIT_COMMIT) -X github.com/sapcc/vpa_butler/cmd.BuildDate=$(BUILD_DATE)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/vpa_butler/main.go && chmod +x bin/$*/$(BINARY)
 
 build:
 	docker build $(OPTS) -t $(IMAGE):$(VERSION) .
-
-static-check:
-	@if s="$$(gofmt -s -l *.go pkg 2>/dev/null)"                            && test -n "$$s"; then printf ' => %s\n%s\n' gofmt  "$$s"; false; fi
-	@if s="$$(golint . && find pkg -type d -exec golint {} \; 2>/dev/null)" && test -n "$$s"; then printf ' => %s\n%s\n' golint "$$s"; false; fi
-
-tests: all static-check
-	DEBUG=1 && go test -v github.com/sapcc/kubernetes-operators/kube-fip-controller/pkg/controller
 
 push: build
 	docker push $(IMAGE):$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+DATE    = $(shell date +%Y%m%d%H%M)
+IMAGE   ?= keppel.eu-de-1.cloud.sap/ccloud/vpa_butler
+VERSION ?= v0.0.6
+GOOS    ?= $(shell go env | grep GOOS | cut -d'"' -f2)
+BINARY  := vpa_butler
+OPTS    ?=
+
+SRCDIRS  := cmd internal
+PACKAGES := $(shell find $(SRCDIRS) -type d)
+GO_PKG	 := github.com/sapcc/vpa_butler
+GOFILES  := $(addsuffix /*.go,$(PACKAGES))
+GOFILES  := $(wildcard $(GOFILES))
+
+.PHONY: all clean vendor tests static-check
+
+all: bin/$(GOOS)/$(BINARY)
+
+bin/%/$(BINARY): GIT_COMMIT  = $(shell git rev-parse --short HEAD)
+bin/%/$(BINARY): BUILD_DATE  = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+bin/%/$(BINARY): $(GOFILES) Makefile
+	GOOS=$* GOARCH=amd64 go build -ldflags '-X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildCommit=$(GIT_COMMIT) -X github.com/sapcc/kubernetes-operators/kube-fip-controller/cmd.BuildDate=$(BUILD_DATE)' -mod vendor -v -o bin/$*/$(BINARY) ./cmd/main.go && chmod +x bin/$*/$(BINARY)
+
+build:
+	docker build $(OPTS) -t $(IMAGE):$(VERSION) .
+
+static-check:
+	@if s="$$(gofmt -s -l *.go pkg 2>/dev/null)"                            && test -n "$$s"; then printf ' => %s\n%s\n' gofmt  "$$s"; false; fi
+	@if s="$$(golint . && find pkg -type d -exec golint {} \; 2>/dev/null)" && test -n "$$s"; then printf ' => %s\n%s\n' golint "$$s"; false; fi
+
+tests: all static-check
+	DEBUG=1 && go test -v github.com/sapcc/kubernetes-operators/kube-fip-controller/pkg/controller
+
+push: build
+	docker push $(IMAGE):$(VERSION)
+
+clean:
+	rm -rf bin/*
+
+vendor:
+	go mod tidy && go mod vendor

--- a/cmd/vpa_butler/main.go
+++ b/cmd/vpa_butler/main.go
@@ -21,6 +21,7 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	Version  string
 )
 
 func init() {
@@ -94,11 +95,12 @@ func main() {
 	}
 	err = statefulSetController.SetupWithManager(mgr)
 	handleError(err, "unable to setup statefulset controller")
-	cleanupController := controllers.VPACleanupController{
-		Client: mgr.GetClient(),
+	vpaController := controllers.VPAController{
+		Client:  mgr.GetClient(),
+		Version: Version,
 	}
-	err = cleanupController.SetupWithManager(mgr)
-	handleError(err, "unable to setup cleanup controller")
+	err = vpaController.SetupWithManager(mgr)
+	handleError(err, "unable to setup vpa controller")
 	setupLog.Info("starting manager")
 	err = mgr.Start(ctrl.SetupSignalHandler())
 	handleError(err, "problem running manager")

--- a/cmd/vpa_butler/main.go
+++ b/cmd/vpa_butler/main.go
@@ -77,6 +77,7 @@ func main() {
 		Namespace:          "",
 		SyncPeriod:         &syncPeriod,
 	})
+
 	handleError(err, "unable to start manager")
 	deploymentController := controllers.VPADeploymentController{
 		Client: mgr.GetClient(),
@@ -93,6 +94,11 @@ func main() {
 	}
 	err = statefulSetController.SetupWithManager(mgr)
 	handleError(err, "unable to setup statefulset controller")
+	cleanupController := controllers.VPACleanupController{
+		Client: mgr.GetClient(),
+	}
+	err = cleanupController.SetupWithManager(mgr)
+	handleError(err, "unable to setup cleanup controller")
 	setupLog.Info("starting manager")
 	err = mgr.Start(ctrl.SetupSignalHandler())
 	handleError(err, "problem running manager")

--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -85,7 +85,7 @@ func GetVPAName(vpaOwner client.Object) string {
 	name := vpaOwner.GetName()
 	kind := strings.ToLower(vpaOwner.GetObjectKind().GroupVersionKind().Kind)
 	if len(name)+len(kind) > 63 {
-		name = name[0 : len(name)-len(kind)]
+		name = name[0 : len(name)-len(kind)-1]
 	}
 	return fmt.Sprintf("%s-%s", name, kind)
 }

--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -3,7 +3,9 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,11 +27,10 @@ const ( // They should complete the sentence "Deployment default/foo has been ..
 	OperationResultUpdated OperationResult = "updated"
 )
 
-func ReconcileVPA(ctx context.Context, c client.Client, scheme *runtime.Scheme, vpaOwner client.Object) (OperationResult, error) {
+func ReconcileVPA(ctx context.Context, c client.Client, scheme *runtime.Scheme, vpaOwner client.Object, log logr.Logger) (OperationResult, error) {
 	var vpa = new(vpav1.VerticalPodAutoscaler)
 	vpa.Namespace = vpaOwner.GetNamespace()
-	vpa.Name = vpaOwner.GetName()
-
+	vpa.Name = GetVPAName(vpaOwner)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(vpa), vpa); err != nil {
 		// Return any other error.
 		if !apierrors.IsNotFound(err) {
@@ -46,7 +47,7 @@ func ReconcileVPA(ctx context.Context, c client.Client, scheme *runtime.Scheme, 
 	}
 
 	// Return here if the butler does not manage this VPA.
-	if !isHandleVPA(vpa) {
+	if !IsHandleVPA(vpa) {
 		return OperationResultNone, nil
 	}
 
@@ -78,4 +79,24 @@ func ignoreAlreadyExists(err error) error {
 		return nil
 	}
 	return err
+}
+
+func GetVPAName(vpaOwner client.Object) string {
+	name := vpaOwner.GetName()
+	kind := strings.ToLower(vpaOwner.GetObjectKind().GroupVersionKind().Kind)
+	if len(name)+len(kind) > 63 {
+		name = name[0 : len(name)-len(kind)]
+	}
+	return fmt.Sprintf("%s-%s", name, kind)
+}
+
+func IsNewNamingSchema(name string) bool {
+	suffixes := []string{"-daemonset", "-statefulset", "-deployment"}
+	for _, prefix := range suffixes {
+		if strings.HasSuffix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/common/vpa.go
+++ b/internal/common/vpa.go
@@ -19,7 +19,7 @@ var (
 	VPAControlledValues = vpav1.ContainerControlledValuesRequestsOnly
 )
 
-func isHandleVPA(vpa *vpav1.VerticalPodAutoscaler) bool {
+func IsHandleVPA(vpa *vpav1.VerticalPodAutoscaler) bool {
 	if vpa.Annotations == nil {
 		return false
 	}

--- a/internal/common/vpa.go
+++ b/internal/common/vpa.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	annotationManagedBy = "managedBy"
-	annotationVPAButler = "vpa_butler"
+	AnnotationManagedBy        = "managedBy"
+	AnnotationVPAButler        = "vpa_butler"
+	AnnotationVPAButlerVersion = "cloud.sap/vpa-butler-version"
 )
 
 var (
@@ -23,8 +24,8 @@ func IsHandleVPA(vpa *vpav1.VerticalPodAutoscaler) bool {
 	if vpa.Annotations == nil {
 		return false
 	}
-	v, ok := vpa.Annotations[annotationManagedBy]
-	return ok && v == annotationVPAButler
+	v, ok := vpa.Annotations[AnnotationManagedBy]
+	return ok && v == AnnotationVPAButler
 }
 
 func mutateVPA(scheme *runtime.Scheme, vpaOwner client.Object, vpa *vpav1.VerticalPodAutoscaler) error {
@@ -51,7 +52,7 @@ func mutateVPA(scheme *runtime.Scheme, vpaOwner client.Object, vpa *vpav1.Vertic
 	if vpa.Annotations == nil {
 		vpa.Annotations = make(map[string]string, 0)
 	}
-	vpa.Annotations[annotationManagedBy] = annotationVPAButler
+	vpa.Annotations[AnnotationManagedBy] = AnnotationVPAButler
 
 	return controllerutil.SetOwnerReference(vpaOwner, vpa, scheme)
 }

--- a/internal/controllers/cleanup-controller.go
+++ b/internal/controllers/cleanup-controller.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/sapcc/vpa_butler/internal/common"
+	"k8s.io/apimachinery/pkg/runtime"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type VPACleanupController struct {
+	client.Client
+	log    logr.Logger
+	scheme *runtime.Scheme
+}
+
+func (v *VPACleanupController) SetupWithManager(mgr ctrl.Manager) error {
+	name := "cleanup-controller"
+	v.Client = mgr.GetClient()
+	v.log = mgr.GetLogger().WithName(name)
+	v.scheme = mgr.GetScheme()
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		For(&vpav1.VerticalPodAutoscaler{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1, Log: v.log}).
+		Complete(v)
+}
+
+func (v *VPACleanupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var vpa = new(vpav1.VerticalPodAutoscaler)
+	if err := v.Get(ctx, req.NamespacedName, vpa); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !common.IsNewNamingSchema(vpa.GetName()) && common.IsHandleVPA(vpa) {
+		err := v.Delete(ctx, vpa)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		v.log.Info("Cleanup old VPA successful", "namespace", vpa.GetNamespace(), "name", vpa.GetName())
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controllers/daemonset-controller.go
+++ b/internal/controllers/daemonset-controller.go
@@ -41,7 +41,7 @@ func (v *VPADaemonsetController) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, daemon)
+	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, daemon, v.log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/deployment-controller.go
+++ b/internal/controllers/deployment-controller.go
@@ -42,7 +42,7 @@ func (v *VPADeploymentController) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, deploy)
+	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, deploy, v.log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/statefulset-controller.go
+++ b/internal/controllers/statefulset-controller.go
@@ -42,7 +42,7 @@ func (v *VPAStatefulSetController) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, statefulset)
+	result, err := common.ReconcileVPA(ctx, v.Client, v.scheme, statefulset, v.log)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
This PR changes the naming schema of created VPA resources. Resources got constantly reconciled when there are originating resources with the same name. It also cleans up resources belonging to the old naming schema.